### PR TITLE
include a missing header

### DIFF
--- a/test/test-main.cc
+++ b/test/test-main.cc
@@ -21,6 +21,9 @@
  */
 
 #include <gtest/gtest.h>
+#ifdef _WIN32
+# include <crtdbg.h>
+#endif
 
 int main(int argc, char **argv) {
 #ifdef _WIN32


### PR DESCRIPTION
without this mingw can't compile the file due to undefined `_CRT_ERROR` etc

should be pretty noncontroversial
