### PR TITLE
Solaris

### DIFF
--- a/src/asl/CMakeLists.txt
+++ b/src/asl/CMakeLists.txt
@@ -323,6 +323,14 @@ if (MP_CLANG)
   add_c_compiler_flags(tableproxy -Wno-string-plus-int)
 endif ()
 
+# Special treatment for solaris, see
+# 1. http://stackoverflow.com/questions/3905829/linking-error-in-sun-studio-10-under-solaris
+# 2. https://github.com/rtv/Stage/blob/master/cmake/internal/FindOS.cmake
+STRING (REGEX MATCH "SunOS" PROJECT_OS_SOLARIS ${CMAKE_SYSTEM_NAME})
+IF (PROJECT_OS_SOLARIS)
+  target_link_libraries(tableproxy socket nsl)
+ENDIF (PROJECT_OS_SOLARIS)
+
 if (WIN32)
   target_link_libraries(ampltabl wsock32)
   target_link_libraries(tableproxy wsock32)

--- a/src/asl/solvers/funcadd1.c
+++ b/src/asl/solvers/funcadd1.c
@@ -21,6 +21,7 @@ IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
 ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
 THIS SOFTWARE.
 ****************************************************************/
+#include <sys/mman.h>
 
 #ifdef NO_FUNCADD
 #include "funcadd.h"

--- a/src/asl/solvers/funcadd1.c
+++ b/src/asl/solvers/funcadd1.c
@@ -21,7 +21,6 @@ IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
 ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF
 THIS SOFTWARE.
 ****************************************************************/
-#include <sys/mman.h>
 
 #ifdef NO_FUNCADD
 #include "funcadd.h"
@@ -42,6 +41,8 @@ funcadd(AmplExports *ae)
 #ifdef WIN32
 #include "windows.h"
 #undef void
+#else
+#include <sys/mman.h> /* not on windows, needed for solaris */
 #endif
 
 #define _POSIX_SOURCE	/* for HP-UX */

--- a/src/os.cc
+++ b/src/os.cc
@@ -46,6 +46,11 @@
 # include <unistd.h>
 #endif
 
+// for solaris compatability
+#ifndef MAP_FILE
+# define MAP_FILE 0x0001
+#endif
+
 #undef getenv
 
 using std::size_t;

--- a/test/nl-reader-test.cc
+++ b/test/nl-reader-test.cc
@@ -157,7 +157,7 @@ TEST(TextReaderTest, ReadDoubleUsesCLocale) {
     .WillOnce(testing::DoAll(testing::SetArgReferee<0>(str + 1), Return(1.23)));
   EXPECT_EQ(1.23, reader.ReadDouble());
   TextReader default_reader(str, "test.nl");
-  fmt::Locale &locale = default_reader.locale();
+  mp::internal::Locale &locale = default_reader.locale();
   mp::internal::Unused(&locale);
 }
 


### PR DESCRIPTION
These modifications allowed me to successfully build on solaris. I get the following test failures. I'm happy to revise as needed.

```
t501:gidden> gmake test
Running tests...
Test project /h/u045/gidden/software/mp/build
      Start  1: cmake-test
 1/25 Test  #1: cmake-test .......................   Passed    0.02 sec
      Start  2: function-test
 2/25 Test  #2: function-test ....................***Failed    0.01 sec
      Start  3: cp-test
 3/25 Test  #3: cp-test ..........................***Exception: Other  0.51 sec
      Start  4: util-test
 4/25 Test  #4: util-test ........................***Failed    0.01 sec
      Start  5: assert-test
 5/25 Test  #5: assert-test ......................   Passed    0.01 sec
      Start  6: clock-test
 6/25 Test  #6: clock-test .......................   Passed    0.01 sec
      Start  7: common-test
 7/25 Test  #7: common-test ......................   Passed    0.01 sec
      Start  8: error-test
 8/25 Test  #8: error-test .......................   Passed    0.01 sec
      Start  9: expr-test
 9/25 Test  #9: expr-test ........................   Passed    0.01 sec
      Start 10: expr-visitor-test
10/25 Test #10: expr-visitor-test ................   Passed    0.02 sec
      Start 11: expr-writer-test
11/25 Test #11: expr-writer-test .................   Passed    0.01 sec
      Start 12: nl-reader-test
12/25 Test #12: nl-reader-test ...................***Failed    0.03 sec
      Start 13: option-test
13/25 Test #13: option-test ......................   Passed    0.01 sec
      Start 14: os-test
14/25 Test #14: os-test ..........................***Failed    0.01 sec
      Start 15: problem-test
15/25 Test #15: problem-test .....................   Passed    0.01 sec
      Start 16: solver-test
16/25 Test #16: solver-test ......................***Failed    0.05 sec
      Start 17: suffix-test
17/25 Test #17: suffix-test ......................   Passed    0.01 sec
      Start 18: problem-builder-test
18/25 Test #18: problem-builder-test .............   Passed    0.01 sec
      Start 19: rstparser-test
19/25 Test #19: rstparser-test ...................   Passed    0.01 sec
      Start 20: safeint-test
20/25 Test #20: safeint-test .....................   Passed    0.01 sec
      Start 21: aslexpr-test
21/25 Test #21: aslexpr-test .....................   Passed    0.01 sec
      Start 22: aslbuilder-test
22/25 Test #22: aslbuilder-test ..................   Passed    0.04 sec
      Start 23: aslproblem-test
23/25 Test #23: aslproblem-test ..................***Failed    0.07 sec
      Start 24: solver-c-test
24/25 Test #24: solver-c-test ....................   Passed    0.01 sec
      Start 25: tableproxy-test
25/25 Test #25: tableproxy-test ..................***Exception: Other  0.37 sec

68% tests passed, 8 tests failed out of 25

Total Test time (real) =   1.34 sec

The following tests FAILED:
          2 - function-test (Failed)
          3 - cp-test (OTHER_FAULT)
          4 - util-test (Failed)
         12 - nl-reader-test (Failed)
         14 - os-test (Failed)
         16 - solver-test (Failed)
         23 - aslproblem-test (Failed)
         25 - tableproxy-test (OTHER_FAULT)
Errors while running CTest
gmake: *** [test] Error 8
```