### PR TITLE
Not all Linux have fpu_control.h (that's a glibc specific header)

### DIFF
--- a/src/asl/solvers/fpinit.c
+++ b/src/asl/solvers/fpinit.c
@@ -98,7 +98,7 @@ fpinit_ASL(Void)
 #endif /*APPLE*/
 
 #ifndef ASL_NO_FP_INIT
-#ifdef __linux__ /*{*/
+#ifdef __GLIBC__ /*{*/
 #ifndef NO_fpu_control /*{*/
 #define FP_INIT_DONE
 #include "fpu_control.h"


### PR DESCRIPTION
A portable alternative could be fenv.h? I'm not sure if it's enough.