### PR TITLE
Allow skip building tests with -DBUILD_TESTING=off

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -378,8 +378,11 @@ foreach (module ${MP_MODULES})
   endif ()
 endforeach ()
 
+include(CTest)
 enable_testing()
-add_subdirectory(test)
+if(BUILD_TESTING)
+  add_subdirectory(test)
+endif()
 
 install(DIRECTORY include/mp DESTINATION include)
 install(TARGETS mp DESTINATION lib RUNTIME DESTINATION bin)


### PR DESCRIPTION
See also: https://cmake.org/cmake/help/latest/module/CTest.html