### PR TITLE
Update the gecode interface for gecode 5.x

### DIFF
--- a/solvers/gecode/gecode.ampl
+++ b/solvers/gecode/gecode.ampl
@@ -1,10 +1,10 @@
 # Declarations of suffixes and parameters for Gecode.
 
-# Constraint suffix that specifies consistency level for integer propagators.
-suffix icl integer >= 0 <= 3 IN;
+# Constraint suffix that specifies propagation level for integer propagators.
+suffix ipl integer >= 0 <= 3 IN;
 
-# Possible values for the icl suffix.
-param icl_val = 0;
-param icl_bnd = 1;
-param icl_dom = 2;
-param icl_def = 3;
+# Possible values for the ipl suffix.
+param ipl_def = 0;
+param ipl_val = 1;
+param ipl_bnd = 2;
+param ipl_dom = 3;

--- a/solvers/gecode/gecode.cc
+++ b/solvers/gecode/gecode.cc
@@ -37,11 +37,11 @@ namespace Search = Gecode::Search;
 
 namespace {
 
-const mp::OptionValueInfo INT_CON_LEVELS[] = {
-  {"val", "value propagation or consistency (naive)", Gecode::ICL_VAL},
-  {"bnd", "bounds propagation or consistency",        Gecode::ICL_BND},
-  {"dom", "domain propagation or consistency",        Gecode::ICL_DOM},
-  {"def", "the default consistency for a constraint", Gecode::ICL_DEF}
+const mp::OptionValueInfo INT_PROP_LEVELS[] = {
+  {"val", "value propagation or consistency (naive)", Gecode::IPL_VAL},
+  {"bnd", "bounds propagation or consistency",        Gecode::IPL_BND},
+  {"dom", "domain propagation or consistency",        Gecode::IPL_DOM},
+  {"def", "the default propagation for a constraint", Gecode::IPL_DEF}
 };
 
 const mp::OptionValueInfo VAR_BRANCHINGS[] = {
@@ -76,14 +76,14 @@ const mp::OptionValueInfo VAR_BRANCHINGS[] = {
     IntVarBranch::SEL_AFC_MAX
   },
   {
-    "activity_min",
-    "lowest activity",
-    IntVarBranch::SEL_ACTIVITY_MIN
+    "action_min",
+    "lowest action",
+    IntVarBranch::SEL_ACTION_MIN
   },
   {
-    "activity_max",
-    "highest activity",
-    IntVarBranch::SEL_ACTIVITY_MAX
+    "action_max",
+    "highest action",
+    IntVarBranch::SEL_ACTION_MAX
   },
   {
     "min_min",
@@ -136,13 +136,13 @@ const mp::OptionValueInfo VAR_BRANCHINGS[] = {
     IntVarBranch::SEL_AFC_SIZE_MAX
   },
   {
-    "activity_size_min",
-    "smallest activity by domain size",
-    IntVarBranch::SEL_ACTIVITY_SIZE_MIN},
+    "action_size_min",
+    "smallest action divided by domain size",
+    IntVarBranch::SEL_ACTION_SIZE_MIN},
   {
-    "activity_size_max",
-    "largest activity by domain size",
-    IntVarBranch::SEL_ACTIVITY_SIZE_MAX
+    "action_size_max",
+    "largest action divided by domain size",
+    IntVarBranch::SEL_ACTION_SIZE_MAX
   },
   {
     "regret_min_min",
@@ -232,12 +232,12 @@ const mp::OptionValueInfo RESTART_MODES[] = {
 
 namespace mp {
 
-GecodeProblem::GecodeProblem(int num_vars, Gecode::IntConLevel icl) :
-  vars_(space(), num_vars), obj_irt_(Gecode::IRT_NQ), icl_(icl) {
+GecodeProblem::GecodeProblem(int num_vars, Gecode::IntPropLevel ipl) :
+  vars_(space(), num_vars), obj_irt_(Gecode::IRT_NQ), ipl_(ipl) {
 }
 
 GecodeProblem::GecodeProblem(bool share, GecodeProblem &s) :
-  Gecode::Space(share, s), obj_irt_(s.obj_irt_), icl_(s.icl_) {
+  Gecode::Space(share, s), obj_irt_(s.obj_irt_), ipl_(s.ipl_) {
   vars_.update(*this, share, s.vars_);
   if (obj_irt_ != Gecode::IRT_NQ)
     obj_.update(*this, share, s.obj_);
@@ -255,7 +255,7 @@ void GecodeProblem::SetObj(obj::Type obj_type, const LinExpr &expr) {
 void GecodeProblem::constrain(const Gecode::Space &best) {
   if (obj_irt_ != Gecode::IRT_NQ) {
     rel(*this, obj_, obj_irt_,
-        static_cast<const GecodeProblem&>(best).obj_, icl_);
+        static_cast<const GecodeProblem&>(best).obj_, ipl_);
   }
 }
 
@@ -265,19 +265,19 @@ BoolExpr MPToGecodeConverter::Convert(
   int index = 0;
   for (IteratedLogicalExpr::iterator
       i = e.begin(), end = e.end(); i != end; ++i, ++index) {
-    args[index] = Gecode::expr(problem_, Visit(*i), icl_);
+    args[index] = Gecode::expr(problem_, Visit(*i), ipl_);
   }
   Gecode::BoolVar var(problem_, 0, 1);
-  rel(problem_, op, args, var, icl_);
+  rel(problem_, op, args, var, ipl_);
   return var;
 }
 
 LinExpr MPToGecodeConverter::Convert(IteratedExpr e, VarArgFunc f) {
   IntVarArgs args;
   for (VarArgExpr::iterator i = e.begin(), end = e.end(); i != end; ++i)
-    args << Gecode::expr(problem_, Visit(*i), icl_);
+    args << Gecode::expr(problem_, Visit(*i), ipl_);
   IntVar result(problem_, Gecode::Int::Limits::min, Gecode::Int::Limits::max);
-  f(problem_, args, result, icl_);
+  f(problem_, args, result, ipl_);
   return result;
 }
 
@@ -307,15 +307,15 @@ LinExpr MPToGecodeConverter::ConvertExpr(
   return expr;
 }
 
-Gecode::IntConLevel MPToGecodeConverter::GetICL(int con_index) const {
-  if (!icl_suffix_)
-    return icl_;
-  int value = icl_suffix_.value(con_index);
-  assert(value == Gecode::ICL_VAL || value == Gecode::ICL_BND ||
-         value == Gecode::ICL_DOM || value == Gecode::ICL_DEF);
-  if (value < 0 || value > Gecode::ICL_DEF)
-    throw Error("Invalid value \"{}\" for suffix \"icl\"", value);
-  return static_cast<Gecode::IntConLevel>(value);
+Gecode::IntPropLevel MPToGecodeConverter::GetIPL(int con_index) const {
+  if (!ipl_suffix_)
+    return ipl_;
+  int value = ipl_suffix_.value(con_index);
+  assert(value == Gecode::IPL_VAL || value == Gecode::IPL_BND ||
+         value == Gecode::IPL_DOM || value == Gecode::IPL_DEF);
+  if (value < 0 || value > Gecode::IPL_DEF)
+    throw Error("Invalid value \"{}\" for suffix \"ipl\"", value);
+  return static_cast<Gecode::IntPropLevel>(value);
 }
 
 void MPToGecodeConverter::Convert(const Problem &p) {
@@ -343,19 +343,19 @@ void MPToGecodeConverter::Convert(const Problem &p) {
                     ConvertExpr(obj.linear_expr(), obj.nonlinear_expr()));
   }
 
-  icl_suffix_ = p.suffixes(suf::CON).Find<int>("icl");
+  ipl_suffix_ = p.suffixes(suf::CON).Find<int>("ipl");
 
-  class ICLSetter {
+  class IPLSetter {
    private:
-    Gecode::IntConLevel &icl_;
-    Gecode::IntConLevel saved_value_;
+    Gecode::IntPropLevel &ipl_;
+    Gecode::IntPropLevel saved_value_;
 
    public:
-    ICLSetter(Gecode::IntConLevel &icl, Gecode::IntConLevel new_value) :
-      icl_(icl), saved_value_(icl) {
-      icl = new_value;
+    IPLSetter(Gecode::IntPropLevel &ipl, Gecode::IntPropLevel new_value) :
+      ipl_(ipl), saved_value_(ipl) {
+      ipl = new_value;
     }
-    ~ICLSetter() { icl_ = saved_value_; }
+    ~IPLSetter() { ipl_ = saved_value_; }
   };
 
   // Convert algebraic constraints.
@@ -364,21 +364,21 @@ void MPToGecodeConverter::Convert(const Problem &p) {
     LinExpr con_expr(
         ConvertExpr(con.linear_expr(), con.nonlinear_expr()));
     double lb = con.lb(), ub = con.ub();
-    ICLSetter icl_setter(icl_, GetICL(i));
+    IPLSetter ipl_setter(ipl_, GetIPL(i));
     if (lb <= -inf) {
-      rel(problem_, con_expr <= CastToInt(ub), icl_);
+      rel(problem_, con_expr <= CastToInt(ub), ipl_);
       continue;
     }
     if (ub >= inf) {
-      rel(problem_, con_expr >= CastToInt(lb), icl_);
+      rel(problem_, con_expr >= CastToInt(lb), ipl_);
       continue;
     }
     int int_lb = CastToInt(lb), int_ub = CastToInt(ub);
     if (int_lb == int_ub) {
-      rel(problem_, con_expr == int_lb, icl_);
+      rel(problem_, con_expr == int_lb, ipl_);
     } else {
-      rel(problem_, con_expr >= int_lb, icl_);
-      rel(problem_, con_expr <= int_ub, icl_);
+      rel(problem_, con_expr >= int_lb, ipl_);
+      rel(problem_, con_expr <= int_ub, ipl_);
     }
   }
 
@@ -386,9 +386,9 @@ void MPToGecodeConverter::Convert(const Problem &p) {
   int num_logical_cons = p.num_logical_cons();
   for (int i = 0; i < num_logical_cons; ++i) {
     LogicalExpr e = p.logical_con(i).expr();
-    ICLSetter icl_setter(icl_, GetICL(p.num_algebraic_cons() + i));
+    IPLSetter ipl_setter(ipl_, GetIPL(p.num_algebraic_cons() + i));
     if (e.kind() != expr::ALLDIFF) {
-      rel(problem_, Visit(e), icl_);
+      rel(problem_, Visit(e), ipl_);
       continue;
     }
     PairwiseExpr alldiff = Cast<PairwiseExpr>(e);
@@ -399,9 +399,9 @@ void MPToGecodeConverter::Convert(const Problem &p) {
       if (arg.kind() == expr::VARIABLE)
         args[i] = vars[Cast<Variable>(arg).index()];
       else
-        args[i] = Gecode::expr(problem_, Visit(arg), icl_);
+        args[i] = Gecode::expr(problem_, Visit(arg), ipl_);
     }
-    distinct(problem_, args, icl_);
+    distinct(problem_, args, ipl_);
   }
 }
 
@@ -422,16 +422,16 @@ LinExpr MPToGecodeConverter::VisitIf(IfExpr e) {
   if (false_const && false_const.value() == 0) {
     NumericConstant true_const = Cast<NumericConstant>(then_expr);
     if (true_const && true_const.value() == 1) {
-      Gecode::channel(problem_, Gecode::expr(problem_, condition, icl_), result);
+      Gecode::channel(problem_, Gecode::expr(problem_, condition, ipl_), result);
       return result;
     }
   }
   rel(problem_, result, Gecode::IRT_EQ,
-      Gecode::expr(problem_, Visit(then_expr), icl_),
-      Reify(Gecode::expr(problem_, condition, icl_), Gecode::RM_IMP), icl_);
+      Gecode::expr(problem_, Visit(then_expr), ipl_),
+      Reify(Gecode::expr(problem_, condition, ipl_), Gecode::RM_IMP), ipl_);
   rel(problem_, result, Gecode::IRT_EQ,
-      Gecode::expr(problem_, Visit(else_expr), icl_),
-      Reify(Gecode::expr(problem_, !condition, icl_), Gecode::RM_IMP), icl_);
+      Gecode::expr(problem_, Visit(else_expr), ipl_),
+      Reify(Gecode::expr(problem_, !condition, ipl_), Gecode::RM_IMP), ipl_);
   return result;
 }
 
@@ -450,10 +450,10 @@ LinExpr MPToGecodeConverter::VisitCount(CountExpr e) {
   int index = 0;
   for (CountExpr::iterator
       i = e.begin(), end = e.end(); i != end; ++i, ++index) {
-    args[index] = Gecode::expr(problem_, Visit(*i), icl_);
+    args[index] = Gecode::expr(problem_, Visit(*i), ipl_);
   }
   IntVar result(problem_, 0, e.num_args());
-  Gecode::linear(problem_, args, Gecode::IRT_EQ, result, icl_);
+  Gecode::linear(problem_, args, Gecode::IRT_EQ, result, ipl_);
   return result;
 }
 
@@ -465,8 +465,8 @@ LinExpr MPToGecodeConverter::VisitNumberOf(IteratedExpr e) {
   int num_args = e.num_args();
   IntVarArgs args(num_args - 1);
   for (int i = 1; i < num_args; ++i)
-    args[i - 1] = Gecode::expr(problem_, Visit(e.arg(i)), icl_);
-  count(problem_, args, Gecode::expr(problem_, Visit(e.arg(0)), icl_),
+    args[i - 1] = Gecode::expr(problem_, Visit(e.arg(i)), ipl_);
+  count(problem_, args, Gecode::expr(problem_, Visit(e.arg(0)), ipl_),
       Gecode::IRT_EQ, result);
   return result;
 }
@@ -492,12 +492,12 @@ BoolExpr MPToGecodeConverter::LogicalExprConverter::VisitAllDiff(
   for (int i = 0; i < n; ++i) {
     for (int j = i + 1; j < n; ++j) {
       Gecode::BoolExpr expr = negate ? args[i] == args[j] : args[i] != args[j];
-      logical_args[index++] = Gecode::expr(problem, expr, converter_.icl_);
+      logical_args[index++] = Gecode::expr(problem, expr, converter_.ipl_);
     }
   }
   Gecode::BoolVar var(problem, 0, 1);
   rel(problem, negate ? Gecode::BOT_OR : Gecode::BOT_AND,
-      logical_args, var, converter_.icl_);
+      logical_args, var, converter_.ipl_);
   return var;
 }
 
@@ -594,7 +594,7 @@ GecodeSolver::GecodeSolver()
 : SolverImpl<Problem>(
     "gecode", "gecode " GECODE_VERSION, 20160205, MULTIPLE_SOL),
   output_(false), output_frequency_(1), output_count_(0), solve_code_(-1),
-  icl_(Gecode::ICL_DEF),
+  ipl_(Gecode::IPL_DEF),
   var_branching_(IntVarBranch::SEL_SIZE_MIN),
   val_branching_(IntValBranch::SEL_MIN),
   decay_(1),
@@ -604,7 +604,7 @@ GecodeSolver::GecodeSolver()
 
   set_version("Gecode " GECODE_VERSION);
 
-  AddSuffix("icl", 0, suf::CON);
+  AddSuffix("ipl", 0, suf::CON);
 
   set_option_header(
       "Gecode Options for AMPL\n"
@@ -625,13 +625,13 @@ GecodeSolver::GecodeSolver()
       "Output frequency in seconds. The value should be a positive number.",
       &GecodeSolver::GetOutputFrequency, &GecodeSolver::SetOutputFrequency);
 
-  AddStrOption("icl",
-      "Consistency level for integer propagators. Possible values:\n"
+  AddStrOption("ipl",
+      "Propagation level for integer propagators. Possible values:\n"
       "\n"
       ".. value-table::\n",
-      &GecodeSolver::GetEnumOption<Gecode::IntConLevel>,
-      &GecodeSolver::SetEnumOption<Gecode::IntConLevel>,
-      &icl_, INT_CON_LEVELS);
+      &GecodeSolver::GetEnumOption<Gecode::IntPropLevel>,
+      &GecodeSolver::SetEnumOption<Gecode::IntPropLevel>,
+      &ipl_, INT_PROP_LEVELS);
 
   AddStrOption("var_branching",
       "Variable branching. Possible values:\n"
@@ -726,7 +726,7 @@ void GetSolution(GecodeProblem &gecode_problem, std::vector<double> &solution) {
     solution[j] = vars[j].val();
 }
 
-template<template<template<typename> class, typename> class Meta>
+template<template<typename, template<typename> class> class Meta>
 GecodeSolver::ProblemPtr GecodeSolver::Search(
     Problem &p, GecodeProblem &problem,
     Search::Statistics &stats, SolutionHandler &sh) {
@@ -734,7 +734,7 @@ GecodeSolver::ProblemPtr GecodeSolver::Search(
   unsigned solution_limit = solution_limit_;
   unsigned num_solutions = 0;
   if (problem.has_obj()) {
-    Meta<Gecode::BAB, GecodeProblem> engine(&problem, options_);
+    Meta<GecodeProblem, Gecode::BAB> engine(&problem, options_);
     while (GecodeProblem *next = engine.next()) {
       if (output_)
         Output("{:46}\n", next->obj().val());
@@ -748,7 +748,7 @@ GecodeSolver::ProblemPtr GecodeSolver::Search(
   } else {
     if (solution_limit == UINT_MAX)
       solution_limit = 1;
-    Meta<Gecode::DFS, GecodeProblem> engine(&problem, options_);
+    Meta<GecodeProblem, Gecode::DFS> engine(&problem, options_);
     std::vector<double> solution;
     bool multiple_sol = need_multiple_solutions();
     if (multiple_sol)
@@ -775,7 +775,7 @@ void GecodeSolver::Solve(Problem &p, SolutionHandler &sh) {
   SetStatus(-1, "");
 
   // Set up an optimization problem in Gecode.
-  MPToGecodeConverter converter(p.num_vars(), icl_);
+  MPToGecodeConverter converter(p.num_vars(), ipl_);
   converter.Convert(p);
 
   // Post branching.
@@ -787,12 +787,12 @@ void GecodeSolver::Solve(Problem &p, SolutionHandler &sh) {
     break;
   case IntVarBranch::SEL_AFC_MIN:
   case IntVarBranch::SEL_AFC_MAX:
-  case IntVarBranch::SEL_ACTIVITY_MIN:
-  case IntVarBranch::SEL_ACTIVITY_MAX:
+  case IntVarBranch::SEL_ACTION_MIN:
+  case IntVarBranch::SEL_ACTION_MAX:
   case IntVarBranch::SEL_AFC_SIZE_MIN:
   case IntVarBranch::SEL_AFC_SIZE_MAX:
-  case IntVarBranch::SEL_ACTIVITY_SIZE_MIN:
-  case IntVarBranch::SEL_ACTIVITY_SIZE_MAX:
+  case IntVarBranch::SEL_ACTION_SIZE_MIN:
+  case IntVarBranch::SEL_ACTION_SIZE_MAX:
     var_branch = IntVarBranch(var_branching_, decay_, 0);
     break;
   default:

--- a/solvers/gecode/gecode.h
+++ b/solvers/gecode/gecode.h
@@ -52,12 +52,12 @@ class GecodeProblem: public Gecode::Space {
   Gecode::IntVar obj_;
   Gecode::IntRelType obj_irt_; // IRT_NQ - no objective,
                                // IRT_LE - minimization, IRT_GR - maximization
-  Gecode::IntConLevel icl_;
+  Gecode::IntPropLevel ipl_;
 
   Gecode::Space &space() { return *this; }
 
  public:
-  GecodeProblem(int num_vars, Gecode::IntConLevel icl);
+  GecodeProblem(int num_vars, Gecode::IntPropLevel ipl);
   GecodeProblem(bool share, GecodeProblem &s);
 
   Gecode::Space *copy(bool share);
@@ -75,8 +75,8 @@ class GecodeProblem: public Gecode::Space {
 class MPToGecodeConverter : public ExprVisitor<MPToGecodeConverter, LinExpr> {
  private:
   GecodeProblem problem_;
-  Gecode::IntConLevel icl_;
-  IntSuffix icl_suffix_;
+  Gecode::IntPropLevel ipl_;
+  IntSuffix ipl_suffix_;
   std::vector<LinExpr> common_exprs_;
 
   typedef Gecode::BoolExpr BoolExpr;
@@ -92,7 +92,7 @@ class MPToGecodeConverter : public ExprVisitor<MPToGecodeConverter, LinExpr> {
 
   typedef void (*VarArgFunc)(
       Gecode::Home, const Gecode::IntVarArgs &,
-      Gecode::IntVar, Gecode::IntConLevel);
+      Gecode::IntVar, Gecode::IntPropLevel);
 
   LinExpr Convert(IteratedExpr e, VarArgFunc f);
 
@@ -100,7 +100,7 @@ class MPToGecodeConverter : public ExprVisitor<MPToGecodeConverter, LinExpr> {
 
   LinExpr ConvertExpr(const LinearExpr &linear, NumericExpr nonlinear);
 
-  Gecode::IntConLevel GetICL(int con_index) const;
+  Gecode::IntPropLevel GetIPL(int con_index) const;
 
   class LogicalExprConverter :
       public ExprConverter<LogicalExprConverter, Gecode::BoolExpr> {
@@ -182,8 +182,8 @@ class MPToGecodeConverter : public ExprVisitor<MPToGecodeConverter, LinExpr> {
   }
 
  public:
-  MPToGecodeConverter(int num_vars, Gecode::IntConLevel icl)
-  : problem_(num_vars, icl), icl_(icl) {}
+  MPToGecodeConverter(int num_vars, Gecode::IntPropLevel ipl)
+  : problem_(num_vars, ipl), ipl_(ipl) {}
 
   void Convert(const Problem &p);
 
@@ -297,7 +297,7 @@ class GecodeSolver : public SolverImpl<Problem> {
   int solve_code_;
   std::string status_;
 
-  Gecode::IntConLevel icl_;
+  Gecode::IntPropLevel ipl_;
   Gecode::IntVarBranch::Select var_branching_;
   Gecode::IntValBranch::Select val_branching_;
   double decay_;
@@ -371,20 +371,20 @@ class GecodeSolver : public SolverImpl<Problem> {
               const Gecode::Search::Options &);
   };
 
-#ifdef HAVE_UNIQUE_PTR
+#ifdef MP_USE_UNIQUE_PTR
   typedef std::unique_ptr<GecodeProblem> ProblemPtr;
 #else
   typedef std::auto_ptr<GecodeProblem> ProblemPtr;
 #endif
 
-  template<template<template<typename> class, typename> class Meta>
+  template<template<typename, template<typename> class> class Meta>
   ProblemPtr Search(Problem &p, GecodeProblem &gecode_problem,
                     Gecode::Search::Statistics &stats, SolutionHandler &sh);
 
  public:
   GecodeSolver();
 
-  Gecode::IntConLevel icl() const { return icl_; }
+  Gecode::IntPropLevel ipl() const { return ipl_; }
   Gecode::IntVarBranch::Select var_branching() const { return var_branching_; }
   Gecode::IntValBranch val_branching() const { return val_branching_; }
   const Gecode::Search::Options &options() const { return options_; }

--- a/test/solvers/gecode-test.cc
+++ b/test/solvers/gecode-test.cc
@@ -115,22 +115,22 @@ struct OptionValue {
   T value;
 };
 
-const OptionValue<Gecode::IntConLevel> INT_CON_LEVELS[] = {
-    {"val", Gecode::ICL_VAL},
-    {"bnd", Gecode::ICL_BND},
-    {"dom", Gecode::ICL_DOM},
-    {"def", Gecode::ICL_DEF},
-    {0,     Gecode::ICL_VAL}
+const OptionValue<Gecode::IntPropLevel> INT_PROP_LEVELS[] = {
+    {"val", Gecode::IPL_VAL},
+    {"bnd", Gecode::IPL_BND},
+    {"dom", Gecode::IPL_DOM},
+    {"def", Gecode::IPL_DEF},
+    {0,     Gecode::IPL_VAL}
 };
 
-TEST_F(NLSolverTest, IntConLevelOption) {
-  EXPECT_EQ(Gecode::ICL_DEF, solver_.icl());
+TEST_F(NLSolverTest, IntPropLevelOption) {
+  EXPECT_EQ(Gecode::IPL_DEF, solver_.ipl());
   unsigned count = 0;
-  for (const OptionValue<Gecode::IntConLevel>
-      *p = INT_CON_LEVELS; p->name; ++p, ++count) {
-    solver_.SetStrOption("icl", p->name);
-    EXPECT_EQ(p->name, solver_.GetStrOption("icl"));
-    EXPECT_EQ(p->value, solver_.icl());
+  for (const OptionValue<Gecode::IntPropLevel>
+      *p = INT_PROP_LEVELS; p->name; ++p, ++count) {
+    solver_.SetStrOption("ipl", p->name);
+    EXPECT_EQ(p->name, solver_.GetStrOption("ipl"));
+    EXPECT_EQ(p->value, solver_.ipl());
   }
   EXPECT_EQ(4u, count);
 }
@@ -168,8 +168,8 @@ const OptionValue<IntVarBranch::Select> VAR_BRANCHINGS[] = {
     {"degree_max",        IntVarBranch::SEL_DEGREE_MAX},
     {"afc_min",           IntVarBranch::SEL_AFC_MIN},
     {"afc_max",           IntVarBranch::SEL_AFC_MAX},
-    {"activity_min",      IntVarBranch::SEL_ACTIVITY_MIN},
-    {"activity_max",      IntVarBranch::SEL_ACTIVITY_MAX},
+    {"action_min",        IntVarBranch::SEL_ACTION_MIN},
+    {"action_max",        IntVarBranch::SEL_ACTION_MAX},
     {"min_min",           IntVarBranch::SEL_MIN_MIN},
     {"min_max",           IntVarBranch::SEL_MIN_MAX},
     {"max_min",           IntVarBranch::SEL_MAX_MIN},
@@ -180,8 +180,8 @@ const OptionValue<IntVarBranch::Select> VAR_BRANCHINGS[] = {
     {"degree_size_max",   IntVarBranch::SEL_DEGREE_SIZE_MAX},
     {"afc_size_min",      IntVarBranch::SEL_AFC_SIZE_MIN},
     {"afc_size_max",      IntVarBranch::SEL_AFC_SIZE_MAX},
-    {"activity_size_min", IntVarBranch::SEL_ACTIVITY_SIZE_MIN},
-    {"activity_size_max", IntVarBranch::SEL_ACTIVITY_SIZE_MAX},
+    {"action_size_min",   IntVarBranch::SEL_ACTION_SIZE_MIN},
+    {"action_size_max",   IntVarBranch::SEL_ACTION_SIZE_MAX},
     {"regret_min_min",    IntVarBranch::SEL_REGRET_MIN_MIN},
     {"regret_min_max",    IntVarBranch::SEL_REGRET_MIN_MAX},
     {"regret_max_min",    IntVarBranch::SEL_REGRET_MAX_MIN},


### PR DESCRIPTION
This is a one-way trip, unfortunately.  You gain the ability to use gecode 5.x by losing the ability to use gecode 4.x.  The preprocessor can deal with the code, but I don't know what to do about gecode.ampl.  This resolves https://github.com/ampl/mp/issues/109.