### PR TITLE
Avoid jacop-related crashes due to destructor execution order

### DIFF
--- a/solvers/jacop/java.h
+++ b/solvers/jacop/java.h
@@ -215,7 +215,8 @@ class JVM {
  private:
   JavaVM *jvm_;
   Env env_;
-  static JVM instance_;
+  static JVM *instance_;
+  static void cleanup_jvm();
 
   JVM() : jvm_() {}
   ~JVM();


### PR DESCRIPTION
When Fedora switched from building with OpenJDK 8 to OpenJDK 11 a few months ago, the mp package started failing its tests.  The jacop-test binary, in particular, started segfaulting.  I finally got around to diagnosing the issue.

In `solvers/jacop/java.h`, there is a class named `JVM` which contains a `JavaVM pointer` (`jvm_`) and an environment (`env_`).  There is also a static instance of this class, named `instance_`, which is initialized on the fly when it is first accessed.  The `JVM` destructor is in `solvers/jacop/java.cc`:

```
JVM::~JVM() {
  if (jvm_)
    jvm_->DestroyJavaVM();
}
```

After the jacop tests have run, the test program exits.  This triggers execution of destructors for static and global objects.  At some point, the `ImageFileReaderTable` destructor is run.  This is an object in OpenJDK's `libjimage.so`.  _After that_, the destructor for the static `instance_` object is run, which results in a call to `DestroyJavaVM()`, which then loads `java.lang.Shutdown`.  Part of the class loading process is to check for image resources associated with the class.  This check accesses the already destroyed `ImageFileReaderTable`, thereby causing a segfault.  See https://bugzilla.redhat.com/show_bug.cgi?id=1858054 for more information.

This commit is probably not the best solution, but it does avoid the segfault.  The trick is that `atexit`-registered functions are run before global object destructors.  Consider this more of a bug report with an ugly workaround attached than a real pull request. :-)