### PR TITLE
avoid load of misaligned address warning in BinaryReader

### DIFF
--- a/include/mp/nl-reader.h
+++ b/include/mp/nl-reader.h
@@ -1243,7 +1243,9 @@ class BinaryReader : private InputConverter, public BinaryReaderBase {
   template <typename Int>
   Int ReadInt() {
     token_ = ptr_;
-    return this->Convert(*reinterpret_cast<const Int*>(Read(sizeof(Int))));
+    Int val;
+    memcpy(&val, Read(sizeof(Int)), sizeof(Int));
+    return this->Convert(val);
   }
 
   int ReadUInt() {
@@ -1255,8 +1257,9 @@ class BinaryReader : private InputConverter, public BinaryReaderBase {
 
   double ReadDouble() {
     token_ = ptr_;
-    return this->Convert(
-          *reinterpret_cast<const double*>(Read(sizeof(double))));
+    double val;
+    memcpy(&val, Read(sizeof(double)), sizeof(double));
+    return this->Convert(val);
   }
 
   fmt::StringRef ReadString() {


### PR DESCRIPTION
I got this warning from a sanitizer when reading a .nl file with ReadNLFile:
```
src/amplmp/include/mp/nl-reader.h:1252:25: runtime error: load of misaligned address 0x7fa34d9211f1 for type 'const int', which requires 4 byte alignment
0x7fa34d9211f1: note: pointer points here
 00 00 00  6f 10 00 00 00 6f 02 00  00 00 76 0e 00 00 00 76  24 00 00 00 43 01 00 00  00 6f 10 00 00
              ^ 
src/amplmp/include/mp/nl-reader.h:1252:25: runtime error: load of misaligned address 0x7fa34d921669 for type 'const short int', which requires 2 byte alignment
0x7fa34d921669: note: pointer points here
 00 00 00  73 00 00 43 1d 00 00 00  73 00 00 43 1e 00 00 00  73 00 00 43 1f 00 00 00  73 00 00 43 20
              ^ 
src/amplmp/include/mp/nl-reader.h:1269:25: runtime error: load of misaligned address 0x7fa34d921706 for type 'const double', which requires 8 byte alignment
0x7fa34d921706: note: pointer points here
 00 00 00 6e 7e 69  f6 e5 71 bd 42 bf 76 02  00 00 00 6f 02 00 00 00  6e 96 0f f7 47 ce 78 71  3f 76
             ^ 
```
This pull request fixes this by copying the bytes to an aligned memory instead of casting.