### PR TITLE
Update model-guide.rst

### DIFF
--- a/doc/rst/model-guide.rst
+++ b/doc/rst/model-guide.rst
@@ -346,39 +346,31 @@ This operator provides a much more concise alternative to specifying ``!=`` betw
        alldiff {i in I..I+2, j in J..J+2} X[i,j];
 
 
-
-
-Complementarity constraints
+Complementarity operator
 ***********************************
 
-AMPL accepts two kinds of complementarity constraints.
-The first kind, inequality vs inequality, enforces both inequalities
-and makes sure at least one of them is tight:
+- *constr1* complements *constr2*
+    *constr-valued:* Satisfied when both *const1* and *constr2* are satisfied, and at least one of them holds with equality. Each of *constr1* and *constr2* must have the form *expr1 <= expr2* or *expr1 >= expr2* (and the trivial special case *expr1 = expr2* is also recognized).
+- **expr complements constr**
+- **constr complements expr**
+     *constr-valued:* Satisfied when *constr* is satisfied, and when also if *expr* is positive then *constr* holds with equality at its lower bound, or if *expr* is negative then *constr* holds with equality at its upper bound. The *constr*  must have the form *lb <= expr <= ub* or *ub >= expr >= lb* where *lb* and *ub* are lower and upper bound expressions not involving variables.
+    
+The ``complements`` operator provides a convenient, streamlined way of expressing a common kind of relationship between two single-inequality constraints, or between an expression and a double-inequality constraint. This relationship appears in the complementary slackness conditions necessary for optimality of certain optimization problems, and in equilibrium conditions for games and for various physical systems. See `Chapter 19. Complementarity Problems <https://ampl.com/BOOK/CHAPTERS/22-complement.pdf>`_ in the `AMPL book <https://ampl.com/resources/the-ampl-book/>`_ for a detailed presentation.
+
+Certain nonlinear solvers, notably Knitro, handle complementarity constraints natively. For MP-based solvers, the interface converts uses of ``complements`` to equivalent constraints using logical operators.
 
 .. code-block:: ampl
 
-        subject to Pri_Compl {i in PROD}:
-            max(500.0, Price[i]) >= 0 complements
-                sum {j in ACT} io[i,j] * Level[j] >= demand[i];
-
-The second kind, range constraint vs expression,
-enforces one of the following 3 cases:
-
-1. range constraint at lower bound  and  expression >= 0;
-2. range constraint valid and expression == 0;
-3. range constraint at upper bound and expression <= 0, for example:
+    subject to Pri_Compl {i in PROD}:
+       Price[i] >= 0 complements
+          sum {j in ACT} io[i,j] * Level[j] >= demzero[i] - demrate[i] * Price[i];
 
 .. code-block:: ampl
 
-        subject to Lev_Compl {j in ACT}:
-            level_min[j] <= Level[j] <= level_max[j] complements
-                cost[j] - sum {i in PROD} Price[i] * io[i,j];
+    subject to Lev_Compl {j in ACT}:
+       level_min[j] <= Level[j] <= level_max[j] complements
+          cost[j] - sum {i in PROD} Price[i] * io[i,j];
 
-See the `AMPL book <https://ampl.com/resources/the-ampl-book/>`_
-for more information.
-
-Quadratic expressions are allowed. For MIP solvers, complementarity
-conditions are represented by logical constraints.
 
 
 General combinatorial expressions

--- a/doc/rst/model-guide.rst
+++ b/doc/rst/model-guide.rst
@@ -275,7 +275,7 @@ AMPL’s ``count`` operator examines an indexed collection of constraints, and r
         atmost cap[k] {j in JOBS} (MachineForJob[j] = k);
 
 - numberof *expr0* in ({indexing} *expr*)
-    *expr-valued:* The number of members of the indexing set such that the **expr** is equal to **expr0**.
+    *expr-valued:* The number of members of the indexing set such that the *expr* is equal to *expr0*.
 
 This operator provides an easier-to-read alternative for a special case of count. Compare for example the ``CapacityOfMachine`` constraint below to the one given previously using ``atmost``.
 
@@ -288,6 +288,49 @@ This operator provides an easier-to-read alternative for a special case of count
 
     subj to MinInGrpDefn {j in 1..numberGrps}:  
        MinInGrp <= numberof j in ({i in PEOPLE} Assign[i]);
+
+
+Comparison operators
+***********************************
+
+- expr1 > expr2
+    *constr-valued:* Satisfied when *expr1* is strictly greater than *expr2*.
+- expr1 < expr2
+    *constr-valued:* Satisfied when *expr1* is strictly less than *expr2*.
+- expr1 != expr2
+    *constr-valued:* Satisfied when *expr1* does not equal *expr2*.
+
+Where possible, the MP interface transforms these operations to ones involving ``>=`` and ``<=``, so that optimization solvers can handle them. For example, this can be done when *expr1* and *expr2* are integer-valued, or when an expression like ``if Flow[i,j] > 0 then fixed[i,j]`` expresses a fixed cost in an objective to be minimized. Where this is not possible, a small tolerance is introduced as disucssed in the section above on **Expressions supported**.
+
+.. code-block:: ampl
+
+    minimize TotalCost:
+       sum {p in PRODUCTS, (i,j) in ARCS} var_cost[p,i,j] * Flow[p,i,j] +
+       sum {(i,j) in ARCS}
+          if sum {p in PRODUCTS} Flow[p,i,j] > 0 then fix_cost[i,j];
+
+.. code-block:: ampl
+
+    subject to Different_Colors {(c1,c2) in Neighbors}:
+       Color[c1] != Color[c2];
+
+- alldiff {indexing} *expr*
+    *constr-valued:* Satisfied when *expr* takes a different value for every member of the indexing set.
+
+- alldiff ( {indexing} *var-expr1*, {indexing} *var-expr2*, ... )
+    *constr-valued:* Similar to the above, but with a list of operands, each optionally indexed.
+
+This operator provides a much more concise alternative to specifying ``!=`` between all pairs in a specified collection of expressions. Currently none of the MP-based solvers support this operator natively, so the interface transforms it to a representation in terms of simpler constraints that use relational operators.
+
+.. code-block:: ampl
+
+    subject to OnePersonPerPosition:
+       alldiff {i in 1..nPeople} Pos[i]; 
+
+.. code-block:: ampl
+
+    subject to Regions {I in 1..9 by 3, J in 1..9 by 3}:
+       alldiff {i in I..I+2, j in J..J+2} X[i,j];
 
 
 
@@ -353,31 +396,6 @@ are having serious problems getting the solver to return a solution.
 
 
 
-
-
-
-Pairwise operator
-~~~~~~~~~~~~~~~~~
-
-Various assignment and related combinatorial problems require that
-a collection of entities be pairwise different or disjoint. Operator ``alldiff``
-makes these conditions easier to state and helps to make the resulting problems
-easier to solve.
-
-In general, this operator can be applied to any collection of expressions
-involving variables:
-
-- alldiff {indexing} *var-expr*
-- alldiff ( {indexing} *var-expr1*, {indexing} *var-expr2*, ... )
-    Satisfied iff all of the specified variables take different values. Each
-    {indexing} may be any AMPL indexing-expression, or may be omitted to
-    specify a single item in the list.
-
-.. code-block:: ampl
-
-        ## implied alldiff
-        subj to VisitOnce {j in BOATS}:
-            isH[j] = 0 ==> alldiff {t in TIMES} H[j,t];
 
 
 

--- a/doc/rst/model-guide.rst
+++ b/doc/rst/model-guide.rst
@@ -1,7 +1,9 @@
 .. _modeling-guide:
 
-Modeling Guide for MP-based AMPL Solvers
+Modeling Guide 
 =========================
+for MP-based AMPL Solvers
+-------------------------
 
 AMPL's newly extended C++ solver interface library, MP, is publicly available in the `ampl/mp <https://github.com/ampl/mp>`_ repository. Solver interfaces built with MP are able to handle a significantly expanded range of model expressions. Currently available MP-based solvers include:
 
@@ -39,10 +41,19 @@ The slides from our presentation on `Advances in Model-Based Optimization <https
 Expressions supported
 ---------------------
 
-The MP solver interface library works with existing AMPL syntaxes, but allows them to be used in more general ways, or with a greater variety of solvers. In many cases, an extension results from allowing variables to appear in more general contexts, such as with conditional, logical, or counting operators. Other extensions are enabled by providing more powerful transformations, particularly to linear or quadratic equivalents, and by providing support for extensions that are native to some solvers. A few extensions are already handled in the AMPL language translator, and are included here for completeness.
+The MP solver interface library works with existing AMPL syntaxes, but allows them to be used in more general ways, or with a greater variety of solvers.
 
-.. MP supports arbitrary trees of logical, relational, general combinatorial,
-.. and non-linear expressions including higher-degree polynomials:
+In many cases, an extension results from allowing variables to appear in more general contexts, such as with conditional, logical, or counting operators. Other extensions are enabled by providing more powerful transformations, particularly to linear or quadratic equivalents, and by providing support for extensions that are native to some solvers. A few extensions are already handled in the AMPL language translator, and are included here for completeness.
+
+In the syntax summaries below, there are two main kinds of entities, representing *numerical expressions* and *constraints:*
+
+- **expr** 
+     represents any expression that evaluates to a number. Unless otherwise indicated, it may contain variables. It may be built from familiar arithmetic operators, but also from other operators or functions that return numerical values.
+
+- **constr** 
+     represents a constraint of the model, which may evaluate to true or false depending the values of variables that it contains. It may be built from the familiar relational operators ``>=``, ``<=``, and ``=``, but also from other operators such as ``or`` and ``alldiff`` that create constraints.
+
+Thus it is possible to build up complex combinations of numerical and logical operators; for example,
 
 .. code-block:: ampl
 
@@ -50,23 +61,16 @@ The MP solver interface library works with existing AMPL syntaxes, but allows th
                 (x<=-5 or
                         (max((x+1)*(x+2)*(y+3), y)<=3 and exp((x+18)*y)<=12));
 
-.. Below are details on the various kinds of expressions and how they are presented
-.. to the solvers.
+AMPL represents these as expression trees, which are sent to MP-based solver interfaces to be processed as particular solvers require.
 
 
 Conditional operators
 ***********************************
 
-AMPL already provides an ``if-then-else`` operator that returns a value
-that can be used in expressions:
-
-- if *logical-expr* then *object-expr*
-    Takes the value of *object-expr* when the *logical-expr* is true, 
-    and the value 0 when the *logical-expr* is false.
-
-- if *logical-expr* then *object-expr1* else *object-expr2*
-    Takes the value of *object-expr1* when the *logical-expr* is true, and the value
-    of *object-expr2* when the *logical-expr* is false.
+- if *constr* then *expr1* [else *expr2*]
+    When *constr* is satisfied, takes the value of *expr1*;  
+    when *constr* is not satisfied, takes the value of *expr2*,
+    or 0 if the `else` phrase is omitted.
 
 When this operator appears in a constraint, the *logical-expr*
 can contain variables, in which case AMPL handles the constraint like

--- a/doc/rst/model-guide.rst
+++ b/doc/rst/model-guide.rst
@@ -39,8 +39,10 @@ The slides from our presentation on `Advances in Model-Based Optimization <https
 Expressions supported
 ---------------------
 
-MP supports arbitrary trees of logical, relational, general combinatorial,
-and non-linear expressions including higher-degree polynomials:
+The MP solver interface library works with existing AMPL syntaxes, but allows them to be used in more general ways, or with a greater variety of solvers. In many cases, an extension results from allowing variables to appear in more general contexts, such as with conditional, logical, or counting operators. Other extensions are enabled by providing more powerful transformations, particularly to linear or quadratic equivalents, and by providing support for extensions that are native to some solvers. A few extensions are already handled in the AMPL language translator, and are included here for completeness.
+
+.. MP supports arbitrary trees of logical, relational, general combinatorial,
+.. and non-linear expressions including higher-degree polynomials:
 
 .. code-block:: ampl
 
@@ -48,8 +50,8 @@ and non-linear expressions including higher-degree polynomials:
                 (x<=-5 or
                         (max((x+1)*(x+2)*(y+3), y)<=3 and exp((x+18)*y)<=12));
 
-Below are details on the various kinds of expressions and how they are presented
-to the solvers.
+.. Below are details on the various kinds of expressions and how they are presented
+.. to the solvers.
 
 
 Conditional operators

--- a/doc/rst/model-guide.rst
+++ b/doc/rst/model-guide.rst
@@ -53,7 +53,7 @@ In the syntax summaries below, there are two main kinds of entities, representin
 - **constr** 
      represents a constraint of the model, which may evaluate to true or false depending the values of variables that it contains. It may be built from the familiar relational operators ``>=``, ``<=``, and ``=``, but also from other operators such as ``or`` and ``alldiff`` that create constraints.
 
-Thus it is possible to build up complex combinations of numerical and logical operators; for example,
+The return value of an operator or function is also either an *expr* or *constr*, as indicated. Thus it is possible to build up complex combinations of numerical and logical operators; for example,
 
 .. code-block:: ampl
 
@@ -68,21 +68,32 @@ Conditional operators
 ***********************************
 
 - if *constr* then *expr1* [else *expr2*]
-    When *constr* is satisfied, takes the value of *expr1*;  
-    when *constr* is not satisfied, takes the value of *expr2*,
-    or 0 if the `else` phrase is omitted.
+    *Returns expr:* When *constr* is true, takes the value of *expr1*.  
+    When *constr* is false, takes the value of *expr2*, or 0 if the `else` phrase is omitted.
 
-When this operator appears in a constraint, the *logical-expr*
-can contain variables, in which case AMPL handles the constraint like
-other nonlinear constraints, passing an expression tree to the solver.
-In particular, the *logical-expr* may be any valid *constraint-expr*.
+In the special case where there are no variables in the *constr*, the value of this expression can be determined as either *expr1* or *expr2* (or 0) before the problem is sent to the solver. But in general, the expression's value depends upon how the solver sets the variables in the *constr*, and so AMPL must send the entire expression to the solver interface for processing.
 
 .. code-block:: ampl
 
-        ## if-then
-        minimize TotalCost:
-            sum {j in JOBS, k in MACHINES}
-                if MachineForJob[j] = k then cost[j,k];
+       minimize TotalCost:
+          sum {j in JOBS, k in MACHINES}
+             if MachineForJob[j] = k then cost[j,k];
+
+.. code-block:: ampl
+
+       subject to Balance {p in PROD, t in TIME}:
+          Make[p,t] + (if t = 0 then inv0[p] else Inv[p,t-1])
+             = Sell[p,t] + Inv[p,t];
+
+- *constr1* ==> *constr2*
+- *constr2* <== *constr1*
+    *Returns constr:* Satistifed if *constr1* is true and *constr2* is true, 
+    or if *constr1* is false. 
+- *constr1* ==> *constr2* else *constr3*
+    *Returns constr:* Satistifed if *constr1* is true and *constr2* is true, 
+    or if *constr1* is false and *constr3* is true. 
+- *constr1* <==> *constr2*
+    *Returns constr:* Satisfied if *constr1* and *constr2* are both true or both false.
 
 
 Logical operators

--- a/doc/rst/model-guide.rst
+++ b/doc/rst/model-guide.rst
@@ -454,10 +454,21 @@ These options can also be overridden for a particular objective or constraint, b
 Set membership operator
 **********************************
 
-- *expr* in *set-expr*
-    *constr-valued:* Satisfied if *expr* is a member of the set given by the AMPL set expression *set-expr*.
+- var *var-name* in *set-expr* ;
+    Defines a variable that must be a member of a specified AMPL set, as given by the expression *set-expr*. All members of the set must be numbers.
 
-*Explanation to come.*
+This is the simplest use of ``in`` to restrict the domain of a set; more generally, the *in set-expr* phrase may appear in any ``var`` definition that does not contain an *=* phrase.
+
+Before sending a problem to the solver interface, AMPL converts variable definitions of this kind to alternative definitions that do not use the ``in`` operator. This may involve the definition of auxiliary binary variables and additional constraints. In the usual case where *set-expr* is a finite set, AMPL also defines suffixes ``.sos`` and ``.sosref`` which can be used by the solver interface to recognize variables and constraints that have been created to implement an ``in`` operator, and to support solvers that handle arbitrary variable domains by means of "special ordered sets of type 1". It is also possible to specify sets that contain continuous intervals -- and hence are infinite -- by using the AMPL expression *interval[expr1,expr2]*.
+
+.. code-block:: ampl
+
+    var Buy {f in FOODS} in {0,10,30,45,55};
+
+.. code-block:: ampl
+
+    var Ship {(i,j) in ARCS}
+       in {0} union interval[min_ship,capacity[i,j]];
 
 
 Efficiency considerations

--- a/doc/rst/model-guide.rst
+++ b/doc/rst/model-guide.rst
@@ -63,6 +63,22 @@ The return value of an operator or function is also one of the above, as indicat
 
 AMPL represents these combinations as expression trees, which are sent to MP-based solver interfaces to be processed as solvers require.
 
+Indexing over sets is a common feature of AMPL expressions. The examples below use two kinds of indexing expressions, which are represented in the syntax summaries as follows:
+
+- { indexing }
+    This is the regular sort of AMPL indexing expression, as used in defining numerous AMPL entities such as parameters, variables, constraints, and summations. It is described in the `AMPL book <https://ampl.com/resources/the-ampl-book/>`_ beginning with `Section 5.5 Indexing expressions <https://ampl.com/BOOK/CHAPTERS/08-sets1.pdf#page=7>`_ and continuing with `Chapter 6. Compound Sets and Indexing <https://ampl.com/BOOK/CHAPTERS/09-sets2.pdf>`_. Followed by an *expr* or *constr*, an indexing expression specifies a list of expressions or constraints to which an operator applies; for example,
+    ::
+        max {n in NODE} weight[t,n] * Use[n]
+        forall {p in PROD} Trans[i,j,p] = 0
+ 
+- ( expr-list )
+    This is a parenthesized, comma-separated list of entries that represent numerical values. Each entry may have the form *expr* or *{indexing} expr*, or recursively *{indexing} ( expr-list )*. For example,
+    ::
+        max (cost["BRO"],cost["CAU"],cost["BRU")
+        max ({f in FOOD} cost[f], 10.0)
+        max ({n in NUTR} (lim_nutr[n], {f in FOOD} amt[n,f])) 
+
+
 Due to the generality of the operators recognized by the MP interface, it is possible to express constraints that do not define a closed feasible region. For example,
 
 .. code-block:: ampl

--- a/doc/rst/model-guide.rst
+++ b/doc/rst/model-guide.rst
@@ -52,23 +52,19 @@ Below are details on the various kinds of expressions and how they are presented
 to the solvers.
 
 
-Conditional and logical expressions
+Conditional operators
 ***********************************
-
-
-Conditional expressions
-~~~~~~~~~~~~~~~~~~~~~~~
 
 AMPL already provides an ``if-then-else`` operator that returns a value
 that can be used in expressions:
 
-- if *logical-expr* then *object-expr1*
+- if *logical-expr* then *object-expr*
+    Takes the value of *object-expr* when the *logical-expr* is true, 
+    and the value 0 when the *logical-expr* is false.
 
 - if *logical-expr* then *object-expr1* else *object-expr2*
-    Takes the value of object-expr1 when the *logical-expr* is true, and the value
-    of *object-expr2* (or 0 if omitted) when the *logical-expr* is false.
-    Both *object-expr*'s must be compatible, i.e., both numbers, strings, or sets.
-
+    Takes the value of *object-expr1* when the *logical-expr* is true, and the value
+    of *object-expr2* when the *logical-expr* is false.
 
 When this operator appears in a constraint, the *logical-expr*
 can contain variables, in which case AMPL handles the constraint like
@@ -83,8 +79,8 @@ In particular, the *logical-expr* may be any valid *constraint-expr*.
                 if MachineForJob[j] = k then cost[j,k];
 
 
-Logical relations
-~~~~~~~~~~~~~~~~~
+Logical operators
+***********************************
 
 AMPL also has a similar if-then form of indexing expression,
 which is used in the context of constraints as follows:

--- a/doc/rst/model-guide.rst
+++ b/doc/rst/model-guide.rst
@@ -409,9 +409,40 @@ Other expressions involving these operators are converted, where possible, to si
 - *expr1* ^ *expr2*
     *expr-valued:* *expr1* raised to the *expr2* power, for the special cases where *expr1* is a positive constant or *expr2* is a constant other than a positive integer.
 
-For the current MP-based solvers, which are limited to linear and quadratic expressions, these univariate functions are handled by piecewise-linear approximation. Expressions using these functions are transformed to use Gurobi's native "function constraints" when possible, and then the approximation is constructed by Gurobi. In other cases, the appoximation is constructed by the MP interface, and is then processed as described previously for piecewise-linear expressions.
+For linear-quadratic MP-based solvers (which include all those currently implemented), these univariate nonlinear functions are handled by piecewise-linear approximation. The appoximation is constructed by the MP interface, using internal settings for the number of pieces and other details, and is then processed as described previously for piecewise-linear expressions.
 
-*Mention support for piecewise-linearization options.*
+For Gurobi, univariate nonlinear functions are instead handled natively. After suitable transformations, the MP interface sends Gurobi the expressions that use these functions, after which the Gurobi solver constructs the piecewise-linear approximations as part of its preprocessing. The choice of approximation can be influenced by setting the following options in an AMPL ``gurobi_options`` string::
+
+  funcpieces
+      Sets the strategy for constructing a piecewise-linear approximation of a 
+      function:
+
+      0   - Automatic choice (default)
+      >=2 - Sets the number of pieces, of equal width
+      1   - Uses a fixed width for each piece, as specified by the
+            funcpiecelength option
+      -1  - Bounds the absolute error of the approximation, as specified
+            by the funcpieceerror option
+      -2  - Bounds the relative error of the approximation, as specified
+            by the funcpieceerror option
+
+  funcpiecelength
+      When funcpieces = 1, specifies the length of each piece of the
+      approximation.
+
+  funcpieceerror
+      When funcpieces = -1 or -2, specifies the maximum allowed
+      error (absolute for -1, relative for -2) in the approximation.
+      
+  funcpieceratio
+      Controls whether the piecewise-linear approximation is an underestimate
+      of the function, an overestimate, or somewhere in between. A value of 
+      0.0 will always underestimate, while a value of 1.0 will always
+      overestimate; a value in between will interpolate between the
+      underestimate and the overestimate. A special value of -1 chooses
+      points that are on the original function.
+
+These options can also be overridden for a particular objective or constraint, by setting suffixes of the same names. For example, after defining the objective shown below, setting ``suffix funcpieces IN; let Chichinadze.funcpieces := 12;`` specifies 12 pieces for approximating the sin, cos, and exp functions in that objective.
 
 .. code-block:: ampl
 

--- a/doc/rst/model-guide.rst
+++ b/doc/rst/model-guide.rst
@@ -78,6 +78,7 @@ Indexing over sets is a common feature of AMPL expressions. The examples below u
         max ({f in FOOD} cost[f], 10.0)
         max ({n in NUTR} (lim_nutr[n], {f in FOOD} amt[n,f])) 
 
+As seen in the case of ``max`` above, certain operators can be used with either the ``{indexing} expr`` or the ``(expr-list)`` form.
 
 Due to the generality of the operators recognized by the MP interface, it is possible to express constraints that do not define a closed feasible region. For example,
 
@@ -173,12 +174,8 @@ Expressions using these operators are transformed to use Gurobi's native AND and
 
 - exists {indexing} *constr*
     *constr-valued:* Satisfied when at least one of the *constr* operands is true.
-- exists ( {indexing1} *constr1*, {indexing2} *constr2*, . . . )
-    *constr-valued:* Similar to the above, but with a list of operands, each optionally indexed.
 - forall {indexing} *constr*
     *constr-valued:* Satisfied when all of the *constr* operands are true.
-- forall ( {indexing1} *constr1*, {indexing2} *constr2*, . . . )
-    *constr-valued:* Similar to the above, but with a list of operands, each optionally indexed.
 
 The ``exists`` and ``forall`` operators are the iterated forms of ``or`` and ``and``, respectively.
 
@@ -207,12 +204,12 @@ Piecewise-linear expressions
     *expr-valued:* Equals *expr* when ≥ 0, or *-expr* when < 0.
 - min {indexing} *expr*
     *expr-valued:* Equals the smallest value among the *expr* operands.
-- min ( {indexing1} *expr1*, {indexing2} *expr2*, . . . )
-    *expr-valued:* Similar to the above, but with a list of operands, each optionally indexed.
+- min ( expr-list )
+    *expr-valued:* Equals the smallest value among all of the operands in the *expr-list*.
 - max {indexing} *expr*
     *expr-valued:* Equals the largest value among the *expr* operands.
-- max ( {indexing1} *expr1*, {indexing2} *expr2*, . . . )
-    *expr-valued:* Similar to the above, but with a list of operands, each optionally indexed.
+- max ( expr-list )
+    *expr-valued:* Equals the largest value among all of the operands in the *expr-list*.
 
 Expressions using these operators are transformed to use Gurobi's native ABS, MIN, and MAX "general constraints" when possible. In other cases, they are transformed to simpler constraints that use relational operators, and in particular are linearized where all of the operands are linear.
 
@@ -290,10 +287,10 @@ AMPL’s ``count`` operator examines an indexed collection of constraints, and r
     subj to CapacityOfMachine {k in MACHINES}:
         atmost cap[k] {j in JOBS} (MachineForJob[j] = k);
 
-- numberof *expr0* in ({indexing} *expr*)
-    *expr-valued:* The number of members of the indexing set such that the *expr* is equal to *expr0*.
+- numberof *expr* in ( *expr-list* )
+    *expr-valued:* The number of items in the *expr-list* have the same value as *expr*.
 
-This operator provides an easier-to-read alternative for a special case of count. Compare for example the ``CapacityOfMachine`` constraint below to the one given previously using ``atmost``.
+This operator can provide an easier-to-read alternative for a special case of count. Compare for example the ``CapacityOfMachine`` constraint below to the one given previously using ``atmost``.
 
 .. code-block:: ampl
 
@@ -333,8 +330,8 @@ Where possible, the MP interface transforms these operations to ones involving `
 - alldiff {indexing} *expr*
     *constr-valued:* Satisfied when *expr* takes a different value for every member of the indexing set.
 
-- alldiff ( {indexing} *var-expr1*, {indexing} *var-expr2*, ... )
-    *constr-valued:* Similar to the above, but with a list of operands, each optionally indexed.
+- alldiff ( expr-list )
+    *constr-valued:* Satisfied when all of the items in the *expr-list* take different values.
 
 This operator provides a much more concise alternative to specifying ``!=`` between all pairs in a specified collection of expressions. Currently none of the MP-based solvers support this operator natively, so the interface transforms it to a representation in terms of simpler constraints that use relational operators.
 


### PR DESCRIPTION
I am revising the modeling guide written by Gleb for MP-based solvers, based on updated categories that I developed for recent talks. I have already made some changes to the develop branch, but has become clear that continuing in that way would leave the guide potentially in a confusing state for a few weeks; thus I am working in a different branch from this point onward.