### PR TITLE
remove check that is always true

### DIFF
--- a/src/nl-reader.cc
+++ b/src/nl-reader.cc
@@ -364,7 +364,7 @@ fmt::StringRef mp::NameProvider::name(
     return fmt::StringRef(name, pos1past - name);
   }
   writer_.clear();
-  if (i2>=0 && index>=i2)
+  if (index>=i2)
     writer_ << gen_name_2_ << '[' << (index - i2 + 1) << ']';
   else
     writer_ << gen_name_ << '[' << (index + 1) << ']';


### PR DESCRIPTION
Fixes compiler warning (`-Wtype-limits`) raised because `i2` is of unsigned type (`std::size_t`), so it is always non-negative.