### PR TITLE
Gurobi: Add missing TAN operation code in nonlinear expressions

### DIFF
--- a/solvers/gurobi/gurobimodelapi.cc
+++ b/solvers/gurobi/gurobimodelapi.cc
@@ -352,6 +352,10 @@ GRB_Expr GurobiModelAPI::AddExpression(const SinExpression& e) {
 GRB_Expr GurobiModelAPI::AddExpression(const CosExpression& e) {
   return CreateFormula(e, GRB_OPCODE_COS);
 }
+GRB_Expr GurobiModelAPI::AddExpression(const TanExpression &e)
+{
+  return CreateFormula(e, GRB_OPCODE_TAN);
+}
 
 GRB_Expr GurobiModelAPI::AddExpression(const DivExpression& e) {
   return CreateFormula(e, GRB_OPCODE_DIVIDE);

--- a/solvers/gurobi/gurobimodelapi.h
+++ b/solvers/gurobi/gurobimodelapi.h
@@ -255,6 +255,8 @@ public:
   Expr AddExpression(const SinExpression& );
   ACCEPT_EXPRESSION(CosExpression, Recommended)
   Expr AddExpression(const CosExpression& );
+  ACCEPT_EXPRESSION(TanExpression, Recommended)
+  Expr AddExpression(const TanExpression& );
 
   ACCEPT_EXPRESSION(DivExpression, Recommended)
   Expr AddExpression(const DivExpression& );


### PR DESCRIPTION
Hello!

When looking at the code, I noticed that Tan was probably missing in the Gurobi driver?

I tested the change on a few cute models that were indeed not correctly converted (yfit, yfitu, cragglvy)