### PR TITLE
fix URL for nlwrite.pdf

### DIFF
--- a/include/mp/nl-reader.h
+++ b/include/mp/nl-reader.h
@@ -4,7 +4,7 @@
  NL is a format for representing optimization problems such as linear,
  quadratic, nonlinear, complementarity and constraint programming problems
  in discrete or continuous variables. It is described in the technical report
- "Writing .nl Files" (http://www.cs.sandia.gov/~dmgay/nlwrite.pdf).
+ "Writing .nl Files" (https://ampl.github.io/nlwrite.pdf).
 
  This is a complete reusable C++ implementation of an NL reader.
 

--- a/nl-writer2/include/mp/nl-feeder.h
+++ b/nl-writer2/include/mp/nl-feeder.h
@@ -8,7 +8,7 @@
  NL is a format for representing optimization problems such as linear,
  quadratic, nonlinear, complementarity and constraint programming problems
  in discrete or continuous variables. It is described in the technical report
- "Writing .nl Files" (http://www.cs.sandia.gov/~dmgay/nlwrite.pdf).
+ "Writing .nl Files" (https://ampl.github.io/nlwrite.pdf).
 
  Usage: recommended via mp::NLSOL class.
 

--- a/nl-writer2/include/mp/nl-solver.h
+++ b/nl-writer2/include/mp/nl-solver.h
@@ -9,7 +9,7 @@
  NL is a format for representing optimization problems such as linear,
  quadratic, nonlinear, complementarity and constraint programming problems
  in discrete or continuous variables. It is described in the technical report
- "Writing .nl Files" (http://www.cs.sandia.gov/~dmgay/nlwrite.pdf).
+ "Writing .nl Files" (https://ampl.github.io/nlwrite.pdf).
 
 
  Copyright (C) 2024 AMPL Optimization, Inc.

--- a/nl-writer2/include/mp/nl-writer2.h
+++ b/nl-writer2/include/mp/nl-writer2.h
@@ -4,7 +4,7 @@
  NL is a format for representing optimization problems such as linear,
  quadratic, nonlinear, complementarity and constraint programming problems
  in discrete or continuous variables. It is described in the technical report
- "Writing .nl Files" (http://www.cs.sandia.gov/~dmgay/nlwrite.pdf).
+ "Writing .nl Files" (https://ampl.github.io/nlwrite.pdf).
 
  This is a complete reusable C++ implementation of an NL writer.
 

--- a/nl-writer2/include/mp/unused/nl-feeder-abstract.h
+++ b/nl-writer2/include/mp/unused/nl-feeder-abstract.h
@@ -7,7 +7,7 @@
  NL is a format for representing optimization problems such as linear,
  quadratic, nonlinear, complementarity and constraint programming problems
  in discrete or continuous variables. It is described in the technical report
- "Writing .nl Files" (http://www.cs.sandia.gov/~dmgay/nlwrite.pdf).
+ "Writing .nl Files" (https://ampl.github.io/nlwrite.pdf).
 
  Usage: recommended via mp::NLSOL class.
  See the MP2NL driver for example implementation.

--- a/nl-writer2/src/nl-writer2.cc
+++ b/nl-writer2/src/nl-writer2.cc
@@ -4,7 +4,7 @@
  NL is a format for representing optimization problems such as linear,
  quadratic, nonlinear, complementarity and constraint programming problems
  in discrete or continuous variables. It is described in the technical report
- "Writing .nl Files" (http://www.cs.sandia.gov/~dmgay/nlwrite.pdf).
+ "Writing .nl Files" (https://ampl.github.io/nlwrite.pdf).
 
  This is a complete reusable C++ implementation of an NL writer.
 


### PR DESCRIPTION
@jamesjer recognized that in some places, still the sandia.gov url was used for nlwrite.pdf: https://github.com/scipopt/scip/issues/183#issuecomment-3603447856

This PR replaces them with the ampl.github.io url.